### PR TITLE
catch browsers not requesting sufficiently large MTU on Android

### DIFF
--- a/src/components/FileExplorer.vue
+++ b/src/components/FileExplorer.vue
@@ -868,10 +868,23 @@ const getDeviceFileCharacteristic = () => {
 let dirList = {};
 
 const handleFileNotifications = (event) => {
+  if (!fileServiceReady.value) return;
+
   let value = event.target.value;
   let offset = 0;
   //console.log('handleFileNotifications');
   if (value.getUint8(offset) == 0x51) {
+    if (value.byteLength == 20) {
+      // issue encountered with Samsung Internet Browser on Android
+      // see https://github.com/WebBluetoothCG/web-bluetooth/issues/284
+      // and https://twitter.com/quicksave2k/status/1460550201064763402
+      message.error("Sufficiently large messages are not supported by your browser. Consider updating or using a different browser instead.", {
+        closable: true,
+        duration: 10000,
+      });
+      fileServiceReady.value = false;
+    }
+
     //console.log(value);
     dirList = {};
     offset++;


### PR DESCRIPTION
First of all, thanks for your work on this, it is very useful to see the content of the littlefs filesystem on the external flash of the PineTime!

However, I had some struggle first to get it to work. Some (extensive) investigation allowed me to understand the concept of the MTU for BLE communication and that on Android it is 23-3 Bytes per default, which is not enough for the BLE FS communication. Apparently the Samsung Internet Browser does not negotiate a larger MTU while Chrome/Chromium for Android does. Unfortunately, there seems to be no way of checking the set MTU directly through the BLE Web API. Therefore, this PR adds a hardcoded check that shows an error message if the file list response has only 20 Bytes.